### PR TITLE
Disable the LearnBot for competition season

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -12,6 +12,6 @@ include ':FtcRobotController'
 include ':Sixteen750'
 include ':Twenty403'
 
+// include ':LearnBot'                                                      // FLIP: BUILD ALL BOTS
 include ':RoadRunnerQuickStart'                                          // FLIP: BUILD ALL BOTS
-include ':LearnBot'                                                      // FLIP: BUILD ALL BOTS
 include ':MeepMeepTesting'                                               // FLIP: BUILD ALL BOTS


### PR DESCRIPTION
This should prevent student (and me, okay, mostly me) from accidentally deploying the wrong bot code.