### PR TITLE
Adjusted odo location constants

### DIFF
--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/commands/driving/JoystickDriveCommand.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/commands/driving/JoystickDriveCommand.java
@@ -44,7 +44,10 @@ public class JoystickDriveCommand implements Command, Loggable {
     // Otherwise, it just reads the rotation value from the rotation stick
     private double getRotation(double headingInRads) {
         // Check to see if we're trying to straighten the robot
-        if (driveStraighten == null || driveStraighten.getAsDouble() < DrivebaseSubsystem.DriveConstants.TRIGGER_THRESHOLD) {
+        if (
+            driveStraighten == null ||
+            driveStraighten.getAsDouble() < DrivebaseSubsystem.DriveConstants.TRIGGER_THRESHOLD
+        ) {
             // No straighten override: return the stick value
             // (with some adjustment...)
             return -Math.pow(r.getAsDouble(), 3) * subsystem.speed;
@@ -79,17 +82,11 @@ public class JoystickDriveCommand implements Command, Loggable {
             double xvalue = -x.getAsDouble();
             if (driveStraighten != null) {
                 if (driveStraighten.getAsDouble() > 0.7) {
-                    if (Math.abs(yvalue) > Math.abs(xvalue))
-                        xvalue = 0;
-                    else
-                        yvalue = 0;
+                    if (Math.abs(yvalue) > Math.abs(xvalue)) xvalue = 0; else yvalue = 0;
                 }
             }
-            Vector2d input = new Vector2d(
-                    yvalue * subsystem.speed,
-                    xvalue * subsystem.speed
-            )
-                    .rotated(curHeading);
+            Vector2d input = new Vector2d(yvalue * subsystem.speed, xvalue * subsystem.speed)
+                .rotated(curHeading);
 
             subsystem.setWeightedDrivePower(
                 new Pose2d(input.getX(), input.getY(), getRotation(curHeading))

--- a/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/controls/DriverController.java
+++ b/Sixteen750/src/main/java/org/firstinspires/ftc/sixteen750/controls/DriverController.java
@@ -22,6 +22,7 @@ public class DriverController {
     public CommandButton resetGyroButton, turboButton, snailButton;
     public CommandButton override;
     public CommandAxis driveStraighten;
+
     public DriverController(CommandGamepad g, Robot r) {
         this.robot = r;
         gamepad = g;
@@ -40,8 +41,6 @@ public class DriverController {
         driveStraighten = gamepad.rightTrigger;
         turboButton = gamepad.rightBumper;
         snailButton = gamepad.leftBumper;
-
-
     }
 
     public void bindDriveControls() {

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/commands/driving/JoystickDriveCommand.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/commands/driving/JoystickDriveCommand.java
@@ -50,7 +50,7 @@ public class JoystickDriveCommand implements Command, Loggable {
         // Check to see if we're trying to straighten the robot
         // Don't straighten in turbo: The bot goes crazy
         if (
-            subsystem.Turbo ||
+            subsystem.isTurboMode() ||
             straightDrive == null ||
             straightDrive.getAsDouble() < TRIGGER_THRESHOLD
         ) {
@@ -72,7 +72,7 @@ public class JoystickDriveCommand implements Command, Loggable {
             // Scale it by the cube root, the scale that down by 30%
             // .9 (about 40 degrees off) provides .96 power => .288
             // .1 (about 5 degrees off) provides .46 power => .14
-            if (subsystem.Snail == true) {
+            if (subsystem.isSnailMode()) {
                 return Math.cbrt(normalized) * SLOW_ROTATION_SCALE;
             } else {
                 return (normalized) * NORMAL_ROTATION_SCALE;

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystems/OdoAccuracy.md
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystems/OdoAccuracy.md
@@ -1,0 +1,38 @@
+# Odo Accuracy
+
+Checking the accuracy of our odo pods when rotating
+
+5 rotations = 5 circumferances = $10 \pi r$
+
+421081 -> Radius is calculated as 13403 ticks
+103964 -> Radius is calculatee as 3309 ticks
+
+TicksPerRev = 8192
+WheelRadius = 17.5 mm
+
+Observed Radius is 1.63611 encoder revolutions
+Observed Radius is .404 encoder revolutions
+
+A revolution is $35\pi$ mm
+
+Observed Radius is 179.9 mm
+Observed Radius is 44.4 mm
+
+For distance, recall that $x^2 + y^2 = r^2$
+thus:
+$x^2 + y^2 = 13403^2 = 179640409$
+$x^2 + y^2 = 3309^2 =  10949481$
+
+Metal chassis is 31.2cm wide
+The drivebase axles are 33.6cm apart
+
+Measured "outer" pod is 17.8cm x 5.2cm from center
+Measured "inner" pod is 7.6cm x 4.9cm from center
+
+#### Turning "error" (slippage on my floor):
+Outer pod -> 0.55cm radius, or about 3% error
+Inner pod -> 4.6cm radius, or about 104% error
+
+Graph of some of this (how I calculated error, in particular)
+
+https://www.desmos.com/calculator/laonl0zuwr

--- a/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystems/TwoDeadWheelLocalizer.java
+++ b/Twenty403/src/main/java/org/firstinspires/ftc/twenty403/subsystems/TwoDeadWheelLocalizer.java
@@ -48,7 +48,7 @@ public class TwoDeadWheelLocalizer
         public static boolean EncoderOverflow = true;
 
         // Our odo pods appear to drive the encoder directly, so no gear ratio
-        public static double GearRatio = 1;
+        public static double GearRatio = 1; // output (wheel) speed / input (encoder) speed
 
         public static double TicksPerRev = 8192;
 
@@ -59,19 +59,17 @@ public class TwoDeadWheelLocalizer
 
         public static boolean perpReverse = true;
         public static boolean paraReverse = false;
+
+        // Parallel/Perpendicular to the forward axis
+        // Parallel wheel is parallel to the forward axis
+        // Perpendicular is perpendicular to the forward axis
+
+        public static double PARALLEL_X = -5.2 / 2.54; // X is the fwd/bkwd direction
+        public static double PARALLEL_Y = -17.8 / 2.54; // Y is the side-to-side/strafe direction
+
+        public static double PERPENDICULAR_X = 4.9 / 2.54; // Was 3 before
+        public static double PERPENDICULAR_Y = 7.6 / 2.54; // Was 3.5 before
     }
-
-    public static double GEAR_RATIO = 1; // output (wheel) speed / input (encoder) speed
-
-    // Parallel/Perpendicular to the forward axis
-    // Parallel wheel is parallel to the forward axis
-    // Perpendicular is perpendicular to the forward axis
-
-    public static double PARALLEL_X = -2; // X is the up and down direction
-    public static double PARALLEL_Y = -7; // Y is the strafe direction
-
-    public static double PERPENDICULAR_X = 3;
-    public static double PERPENDICULAR_Y = 3.5;
 
     // Parallel moves parallel to the axles of the drive base
     @Log(name = "parOdo")
@@ -90,10 +88,14 @@ public class TwoDeadWheelLocalizer
     public TwoDeadWheelLocalizer(MotorEncoder r, MotorEncoder f) {
         super(
             Arrays.asList(
-                new Pose2d(PARALLEL_X, PARALLEL_Y, Math.toRadians(OdoDeadWheelConstants.paraAngle)),
                 new Pose2d(
-                    PERPENDICULAR_X,
-                    PERPENDICULAR_Y,
+                    OdoDeadWheelConstants.PARALLEL_X,
+                    OdoDeadWheelConstants.PARALLEL_Y,
+                    Math.toRadians(OdoDeadWheelConstants.paraAngle)
+                ),
+                new Pose2d(
+                    OdoDeadWheelConstants.PERPENDICULAR_X,
+                    OdoDeadWheelConstants.PERPENDICULAR_Y,
                     Math.toRadians(OdoDeadWheelConstants.perpAngle)
                 )
             )


### PR DESCRIPTION
This may be the reason for less shakiness: The 'closer' odo pod moves a lot more, and the previous constants had it MUCH further away from the center of the both, potentially making the localization code thing the bot was veering to the left or right much more than it actually was. On Friday, we should try before & after with this code and see if it's the cause.